### PR TITLE
Fix navbar overlapping photo

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -25,7 +25,7 @@ const description = "Frontend Developer with over 2 years of experience, special
   <meta name="twitter:image" content="/images/avata.png" />
 </head>
 
-<section class="min-h-screen flex items-center py-8 md:py-12 relative overflow-hidden" id="hero">
+<section class="min-h-screen flex items-center py-8 md:py-12 relative overflow-hidden pt-16" id="hero">
   <div class="container mx-auto px-4 md:px-6 max-w-3xl">
     <!-- Main Content -->
     <div class="flex flex-col items-center md:items-start space-y-6">

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -3,7 +3,7 @@
 ---
 
 <div id="navbar-trigger" class="fixed top-0 left-0 w-full h-16 z-40"></div>
-<nav class="fixed top-0 left-1/2 -translate-x-1/2 z-50 w-fit mt-4 transition-all duration-300 group md:opacity-40 opacity-100">
+<nav class="fixed top-0 left-1/2 -translate-x-1/2 z-10 w-fit mt-4 transition-all duration-300 group md:opacity-40 opacity-100">
   <div class="backdrop-blur-md rounded-3xl bg-white/5 dark:bg-black/5 relative transition-all duration-300
               before:absolute before:inset-0 before:rounded-3xl before:p-[1px] before:bg-gradient-to-r 
               before:from-white/10 before:to-white/20 dark:before:from-white/5 dark:before:to-white/10


### PR DESCRIPTION
Update the navbar and hero section to prevent the navbar from overlapping the photo.

* **Navbar**: Change the `z-index` of the navbar from `50` to `10` in `src/components/Navbar.astro`.
* **Hero Section**: Add a top padding of `16` to the `Hero` section in `src/components/Hero.astro`.

